### PR TITLE
Update Yahoo Finance API Authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+YahooFinanceClient is a Ruby gem providing a client for the Yahoo! Finance API. It fetches stock quotes with built-in caching (5-minute TTL) and handles Yahoo's authentication flow (cookies + CSRF crumb tokens).
+
+**Note**: Yahoo! may have disabled API access - this project is in a work-in-progress state.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `rake` | Run tests and linting (default task) |
+| `rake spec` | Run RSpec tests only |
+| `rake rubocop` | Run RuboCop linter only |
+| `bundle exec rspec spec/yahoo_finance_client/stock_spec.rb` | Run single test file |
+| `bundle exec rake install` | Install gem locally |
+| `bin/console` | Interactive Ruby console for experimentation |
+
+## Architecture
+
+```
+lib/
+├── yahoo_finance_client.rb           # Main module entry point
+└── yahoo_finance_client/
+    ├── stock.rb                      # Core API client (class methods)
+    └── version.rb                    # Version constant
+```
+
+**YahooFinanceClient::Stock** is the main class with a single public interface:
+- `Stock.get_quote(symbol)` - Returns hash with `symbol`, `price`, `change`, `percent_change`, `volume`
+
+The class handles Yahoo's auth flow internally: fetch cookie → get crumb token → make authenticated API request. Results are cached in a class-level hash with 300-second expiration.
+
+## Testing
+
+Uses RSpec with WebMock for HTTP stubbing. Tests clear the cache before each example. Key test patterns:
+- Stub HTTP requests, don't hit real API
+- Test cache behavior via instance variable inspection (`@quotes_cache`)
+- Contexts organize success/failure/cache scenarios
+
+## Code Style
+
+- Ruby 3.4 target
+- Max line length: 120
+- Double quotes for strings
+- Frozen string literals enabled

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yahoo_finance_client (0.1.6)
+    yahoo_finance_client (0.2.0)
       csv
       httparty (~> 0.21.0)
 

--- a/lib/yahoo_finance_client.rb
+++ b/lib/yahoo_finance_client.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-require "yahoo_finance_client/version"
-require "yahoo_finance_client/stock"
 require "httparty"
+require "yahoo_finance_client/version"
+require "yahoo_finance_client/errors"
+require "yahoo_finance_client/session"
+require "yahoo_finance_client/stock"
 
 # Basic Yahoo! Finance client
 module YahooFinanceClient

--- a/lib/yahoo_finance_client/errors.rb
+++ b/lib/yahoo_finance_client/errors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module YahooFinanceClient
+  # Base error class for Yahoo Finance Client
+  class Error < StandardError; end
+
+  # Raised when authentication fails (invalid cookie/crumb)
+  class AuthenticationError < Error; end
+
+  # Raised when Yahoo Finance rate limits requests
+  class RateLimitError < Error; end
+end

--- a/lib/yahoo_finance_client/session.rb
+++ b/lib/yahoo_finance_client/session.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "httparty"
+require "singleton"
+
+module YahooFinanceClient
+  # Handles Yahoo Finance authentication with multiple fallback strategies
+  class Session
+    include Singleton
+
+    SESSION_TTL = 60
+    USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0"
+    COOKIE_URL = "https://fc.yahoo.com"
+    CRUMB_URL_QUERY1 = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+    CRUMB_URL_QUERY2 = "https://query2.finance.yahoo.com/v1/test/getcrumb"
+    HOMEPAGE_URL = "https://finance.yahoo.com"
+    CRUMB_PATTERNS = [/"crumb"\s*:\s*"([^"]+)"/, /"CrsrfToken"\s*:\s*"([^"]+)"/, /crumb=([a-zA-Z0-9_.~-]+)/].freeze
+
+    attr_reader :cookie, :crumb, :base_url
+
+    def initialize
+      reset!
+    end
+
+    def ensure_authenticated
+      return if valid_session?
+
+      authenticate!
+    end
+
+    def invalidate!
+      reset!
+    end
+
+    def valid_session?
+      return false unless @cookie && @crumb && @authenticated_at
+
+      Time.now - @authenticated_at < SESSION_TTL
+    end
+
+    private
+
+    def reset!
+      @cookie = nil
+      @crumb = nil
+      @authenticated_at = nil
+      @base_url = "https://query1.finance.yahoo.com"
+    end
+
+    def authenticate!
+      strategies = %i[strategy_fc_cookie_query1 strategy_homepage_scrape strategy_fc_cookie_query2]
+      strategies.each { |s| return @authenticated_at = Time.now if send(s) rescue nil } # rubocop:disable Style/RescueModifier
+      raise AuthenticationError, "All authentication strategies failed"
+    end
+
+    def strategy_fc_cookie_query1
+      apply_crumb_strategy(fetch_cookie_from_fc, CRUMB_URL_QUERY1, "https://query1.finance.yahoo.com")
+    end
+
+    def strategy_fc_cookie_query2
+      apply_crumb_strategy(fetch_cookie_from_fc, CRUMB_URL_QUERY2, "https://query2.finance.yahoo.com")
+    end
+
+    def apply_crumb_strategy(cookie, crumb_url, base)
+      return false unless cookie
+
+      crumb = fetch_crumb(cookie, crumb_url)
+      return false unless valid_crumb?(crumb)
+
+      @cookie = cookie
+      @crumb = crumb
+      @base_url = base
+      true
+    end
+
+    def strategy_homepage_scrape
+      response = HTTParty.get(HOMEPAGE_URL, headers: request_headers, follow_redirects: true)
+      return false unless response.success?
+
+      cookie = extract_cookie(response)
+      crumb = extract_crumb_from_html(response.body)
+      return false unless cookie && crumb
+
+      @cookie = cookie
+      @crumb = crumb
+      @base_url = "https://query1.finance.yahoo.com"
+      true
+    end
+
+    def fetch_cookie_from_fc
+      extract_cookie(HTTParty.get(COOKIE_URL, headers: request_headers))
+    end
+
+    def fetch_crumb(cookie, crumb_url)
+      response = HTTParty.get(crumb_url, headers: request_headers.merge("Cookie" => cookie))
+      response.success? ? response.body.strip : nil
+    end
+
+    def extract_cookie(response)
+      response.headers["set-cookie"]&.to_s
+    end
+
+    def extract_crumb_from_html(html)
+      CRUMB_PATTERNS.each { |p| (m = html.match(p)) && (return unescape_crumb(m[1])) }
+      nil
+    end
+
+    def unescape_crumb(crumb)
+      crumb.gsub(/\\u([0-9a-fA-F]{4})/) { [::Regexp.last_match(1).to_i(16)].pack("U") }
+    end
+
+    def valid_crumb?(crumb)
+      crumb && !crumb.empty? && !crumb.include?("<") && !crumb.include?("Unauthorized")
+    end
+
+    def request_headers
+      { "User-Agent" => USER_AGENT, "Accept" => "text/html,*/*;q=0.8", "Accept-Language" => "en-US,en;q=0.5" }
+    end
+  end
+end

--- a/lib/yahoo_finance_client/version.rb
+++ b/lib/yahoo_finance_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module YahooFinanceClient
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/spec/yahoo_finance_client/session_spec.rb
+++ b/spec/yahoo_finance_client/session_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "webmock/rspec"
+
+RSpec.describe YahooFinanceClient::Session do
+  let(:session) { described_class.instance }
+  let(:cookie) { "A1=abc123; path=/;" }
+  let(:crumb) { "validCrumb123" }
+
+  before do
+    # Reset singleton state before each test
+    session.send(:reset!)
+  end
+
+  describe "#ensure_authenticated" do
+    context "when strategy 1 (fc.yahoo.com + query1) succeeds" do
+      before do
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: { "set-cookie" => cookie })
+        stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+          .with(headers: { "Cookie" => cookie })
+          .to_return(status: 200, body: crumb)
+      end
+
+      it "authenticates successfully" do
+        session.ensure_authenticated
+        expect(session.cookie).to eq(cookie)
+        expect(session.crumb).to eq(crumb)
+        expect(session.base_url).to eq("https://query1.finance.yahoo.com")
+      end
+
+      it "sets a valid session" do
+        session.ensure_authenticated
+        expect(session.valid_session?).to be true
+      end
+    end
+
+    context "when strategy 1 fails but strategy 2 (homepage scraping) succeeds" do
+      before do
+        # Strategy 1 fails
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: { "set-cookie" => cookie })
+        stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+          .with(headers: { "Cookie" => cookie })
+          .to_return(status: 401, body: "Unauthorized")
+
+        # Strategy 2 succeeds
+        homepage_html = '<script>window.config = {"crumb":"homepageCrumb456"};</script>'
+        stub_request(:get, "https://finance.yahoo.com")
+          .to_return(status: 200, body: homepage_html, headers: { "set-cookie" => "homepage_cookie" })
+      end
+
+      it "falls back to homepage scraping" do
+        session.ensure_authenticated
+        expect(session.cookie).to eq("homepage_cookie")
+        expect(session.crumb).to eq("homepageCrumb456")
+      end
+    end
+
+    context "when strategies 1 and 2 fail but strategy 3 (query2) succeeds" do
+      before do
+        # Strategy 1 fails - crumb request fails
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: { "set-cookie" => cookie })
+        stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+          .to_return(status: 401, body: "Unauthorized")
+
+        # Strategy 2 fails - homepage doesn't have crumb
+        stub_request(:get, "https://finance.yahoo.com")
+          .to_return(status: 200, body: "<html>no crumb here</html>", headers: { "set-cookie" => "homepage_cookie" })
+
+        # Strategy 3 succeeds
+        stub_request(:get, "https://query2.finance.yahoo.com/v1/test/getcrumb")
+          .to_return(status: 200, body: crumb)
+      end
+
+      it "falls back to query2 domain" do
+        session.ensure_authenticated
+        expect(session.base_url).to eq("https://query2.finance.yahoo.com")
+        expect(session.crumb).to eq(crumb)
+      end
+    end
+
+    context "when all strategies fail" do
+      before do
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: {})
+        stub_request(:get, "https://finance.yahoo.com")
+          .to_return(status: 500, body: "")
+        stub_request(:get, "https://query2.finance.yahoo.com/v1/test/getcrumb")
+          .to_return(status: 401, body: "Unauthorized")
+      end
+
+      it "raises AuthenticationError" do
+        expect { session.ensure_authenticated }.to raise_error(YahooFinanceClient::AuthenticationError)
+      end
+    end
+  end
+
+  describe "#valid_session?" do
+    context "when not authenticated" do
+      it "returns false" do
+        expect(session.valid_session?).to be false
+      end
+    end
+
+    context "when authenticated" do
+      before do
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: { "set-cookie" => cookie })
+        stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+          .with(headers: { "Cookie" => cookie })
+          .to_return(status: 200, body: crumb)
+        session.ensure_authenticated
+      end
+
+      it "returns true" do
+        expect(session.valid_session?).to be true
+      end
+    end
+
+    context "when session has expired" do
+      before do
+        stub_request(:get, "https://fc.yahoo.com")
+          .to_return(status: 200, headers: { "set-cookie" => cookie })
+        stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+          .with(headers: { "Cookie" => cookie })
+          .to_return(status: 200, body: crumb)
+        session.ensure_authenticated
+
+        # Simulate time passing beyond SESSION_TTL
+        session.instance_variable_set(:@authenticated_at, Time.now - (described_class::SESSION_TTL + 1))
+      end
+
+      it "returns false" do
+        expect(session.valid_session?).to be false
+      end
+    end
+  end
+
+  describe "#invalidate!" do
+    before do
+      stub_request(:get, "https://fc.yahoo.com")
+        .to_return(status: 200, headers: { "set-cookie" => cookie })
+      stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+        .with(headers: { "Cookie" => cookie })
+        .to_return(status: 200, body: crumb)
+      session.ensure_authenticated
+    end
+
+    it "clears the session" do
+      expect(session.valid_session?).to be true
+      session.invalidate!
+      expect(session.valid_session?).to be false
+      expect(session.cookie).to be_nil
+      expect(session.crumb).to be_nil
+    end
+  end
+
+  describe "crumb extraction from homepage" do
+    let(:homepage_cookie) { "homepage_session=xyz" }
+
+    before do
+      # Strategy 1 fails
+      stub_request(:get, "https://fc.yahoo.com")
+        .to_return(status: 200, headers: { "set-cookie" => cookie })
+      stub_request(:get, "https://query1.finance.yahoo.com/v1/test/getcrumb")
+        .to_return(status: 401, body: "Unauthorized")
+    end
+
+    context "with standard crumb format" do
+      let(:html) { '<script>{"crumb":"abc123def"}</script>' }
+
+      before do
+        stub_request(:get, "https://finance.yahoo.com")
+          .to_return(status: 200, body: html, headers: { "set-cookie" => homepage_cookie })
+      end
+
+      it "extracts the crumb" do
+        session.ensure_authenticated
+        expect(session.crumb).to eq("abc123def")
+      end
+    end
+
+    context "with unicode-escaped crumb" do
+      let(:html) { '<script>{"crumb":"abc\\u002Fdef\\u002Fghi"}</script>' }
+
+      before do
+        stub_request(:get, "https://finance.yahoo.com")
+          .to_return(status: 200, body: html, headers: { "set-cookie" => homepage_cookie })
+      end
+
+      it "decodes unicode escapes" do
+        session.ensure_authenticated
+        expect(session.crumb).to eq("abc/def/ghi")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

The current implementation uses a cookie/crumb authentication flow that Yahoo Finance tightened in mid-2023:
- Cookies now expire faster (often within minutes)
- Crumb extraction from `/v1/test/getcrumb` endpoint may fail
- "Invalid Cookie" and "Invalid Crumb" errors are common

## Research Summary

**Sources:**
- [Yahoo Finance API Fix Guide](https://www.codestudy.net/blog/yahoo-finance-api-get-quotes-returns-invalid-cookie/)
- [yahoo-finance2 issue #764](https://github.com/gadicc/yahoo-finance2/issues/764)
- [yfinance Python library approaches](https://maikros.github.io/yahoo-finance-python/)

**Working approaches from other libraries:**
1. **Basic strategy** (current): fc.yahoo.com cookie + getcrumb - may still work with proper session persistence
2. **Homepage scraping**: Visit finance.yahoo.com, extract crumb via regex `"crumb":"([^"]+)"`
3. **Alternative domain**: Use query2.finance.yahoo.com instead of query1

## Solution

Implement multi-strategy authentication with fallback mechanisms while maintaining backwards compatibility.