### PR TITLE
Add 52-week high/low fields to quote data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## [0.4.1] - 2026-02-13
+
+- Add `fifty_two_week_high` and `fifty_two_week_low` fields to quote data
+
+## [0.4.0] - 2026-02-12
+
+- Add dividend history fetching via chart API (`get_dividend_history`)
+- Update README with bulk quotes, dividend history, and caching docs
+
+## [0.3.1] - 2026-02-12
+
+- Add `ex_dividend_date` and `dividend_date` fields to quote data
+
+## [0.3.0] - 2026-02-10
+
+- Add bulk quotes support with `get_quotes` method
+
+## [0.2.1] - 2026-01-29
+
+- Add extended stock information fields (EPS, PE ratio, dividend data, moving averages)
+
+## [0.2.0] - 2026-01-27
+
+- Add multi-strategy authentication with retry logic
+- Add CLAUDE.md with project instructions
+
 ## [0.1.6] - 2025-02-18
 
 - Adding a simple cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yahoo_finance_client (0.4.0)
+    yahoo_finance_client (0.4.1)
       csv
       httparty (~> 0.21.0)
 

--- a/lib/yahoo_finance_client/stock.rb
+++ b/lib/yahoo_finance_client/stock.rb
@@ -152,6 +152,7 @@ module YahooFinanceClient
           dividend: dividend, dividend_yield: calculate_yield(dividend, price),
           payout_ratio: calculate_payout(dividend, eps),
           ma50: quote["fiftyDayAverage"], ma200: quote["twoHundredDayAverage"],
+          fifty_two_week_high: quote["fiftyTwoWeekHigh"], fifty_two_week_low: quote["fiftyTwoWeekLow"],
           ex_dividend_date: parse_unix_date(quote["exDividendDate"]),
           dividend_date: parse_unix_date(quote["dividendDate"])
         }

--- a/lib/yahoo_finance_client/version.rb
+++ b/lib/yahoo_finance_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module YahooFinanceClient
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/spec/yahoo_finance_client/stock_spec.rb
+++ b/spec/yahoo_finance_client/stock_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "dividendRate" => 0.96,
                 "fiftyDayAverage" => 148.5,
                 "twoHundredDayAverage" => 145.0,
+                "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0,
                 "exDividendDate" => 1_710_374_400
               }
             ]
@@ -64,6 +66,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.33,
           ma50: 148.5,
           ma200: 145.0,
+          fifty_two_week_high: 180.0,
+          fifty_two_week_low: 120.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         }
@@ -140,6 +144,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.33,
           ma50: 148.5,
           ma200: 145.0,
+          fifty_two_week_high: 180.0,
+          fifty_two_week_low: 120.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         }
@@ -176,6 +182,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.33,
           ma50: 148.5,
           ma200: 145.0,
+          fifty_two_week_high: 180.0,
+          fifty_two_week_low: 120.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         }
@@ -197,6 +205,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "dividendRate" => 0.96,
                 "fiftyDayAverage" => 150.0,
                 "twoHundredDayAverage" => 147.0,
+                "fiftyTwoWeekHigh" => 185.0,
+                "fiftyTwoWeekLow" => 125.0,
                 "exDividendDate" => 1_710_374_400
               }
             ]
@@ -219,6 +229,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.11,
           ma50: 150.0,
           ma200: 147.0,
+          fifty_two_week_high: 185.0,
+          fifty_two_week_low: 125.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         }
@@ -258,7 +270,9 @@ RSpec.describe YahooFinanceClient::Stock do
                 "trailingPE" => 22.0,
                 "epsTrailingTwelveMonths" => 6.36,
                 "fiftyDayAverage" => 138.0,
-                "twoHundredDayAverage" => 135.0
+                "twoHundredDayAverage" => 135.0,
+                "fiftyTwoWeekHigh" => 160.0,
+                "fiftyTwoWeekLow" => 110.0
               }
             ]
           }
@@ -286,6 +300,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: nil,
           ma50: 138.0,
           ma200: 135.0,
+          fifty_two_week_high: 160.0,
+          fifty_two_week_low: 110.0,
           ex_dividend_date: nil,
           dividend_date: nil
         )
@@ -345,7 +361,9 @@ RSpec.describe YahooFinanceClient::Stock do
                 "epsTrailingTwelveMonths" => -1.5,
                 "dividendRate" => 0.0,
                 "fiftyDayAverage" => 195.0,
-                "twoHundredDayAverage" => 180.0
+                "twoHundredDayAverage" => 180.0,
+                "fiftyTwoWeekHigh" => 250.0,
+                "fiftyTwoWeekLow" => 150.0
               }
             ]
           }
@@ -373,6 +391,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: nil,
           ma50: 195.0,
           ma200: 180.0,
+          fifty_two_week_high: 250.0,
+          fifty_two_week_low: 150.0,
           ex_dividend_date: nil,
           dividend_date: nil
         )
@@ -396,6 +416,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "dividendRate" => 0.96,
                 "fiftyDayAverage" => 148.5,
                 "twoHundredDayAverage" => 145.0,
+                "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0,
                 "exDividendDate" => 1_710_374_400
               }
             ]
@@ -428,6 +450,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.33,
           ma50: 148.5,
           ma200: 145.0,
+          fifty_two_week_high: 180.0,
+          fifty_two_week_low: 120.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         )
@@ -463,6 +487,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "dividendRate" => 0.96,
                 "fiftyDayAverage" => 148.5,
                 "twoHundredDayAverage" => 145.0,
+                "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0,
                 "exDividendDate" => 1_710_374_400
               }
             ]
@@ -496,6 +522,8 @@ RSpec.describe YahooFinanceClient::Stock do
           payout_ratio: 16.33,
           ma50: 148.5,
           ma200: 145.0,
+          fifty_two_week_high: 180.0,
+          fifty_two_week_low: 120.0,
           ex_dividend_date: Date.new(2024, 3, 14),
           dividend_date: nil
         )
@@ -534,7 +562,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "regularMarketChangePercent" => 1.0, "regularMarketVolume" => 100_000,
                 "trailingPE" => 25.5, "epsTrailingTwelveMonths" => 5.88,
                 "dividendRate" => 0.96, "fiftyDayAverage" => 148.5,
-                "twoHundredDayAverage" => 145.0, "exDividendDate" => 1_710_374_400
+                "twoHundredDayAverage" => 145.0, "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0, "exDividendDate" => 1_710_374_400
               },
               {
                 "symbol" => "MSFT", "shortName" => "Microsoft Corp.",
@@ -542,7 +571,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "regularMarketChangePercent" => 0.53, "regularMarketVolume" => 90_000,
                 "trailingPE" => 35.0, "epsTrailingTwelveMonths" => 10.86,
                 "dividendRate" => 3.0, "fiftyDayAverage" => 375.0,
-                "twoHundredDayAverage" => 360.0, "exDividendDate" => 1_715_644_800
+                "twoHundredDayAverage" => 360.0, "fiftyTwoWeekHigh" => 420.0,
+                "fiftyTwoWeekLow" => 310.0, "exDividendDate" => 1_715_644_800
               }
             ]
           }
@@ -582,7 +612,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "regularMarketChangePercent" => 1.0, "regularMarketVolume" => 100_000,
                 "trailingPE" => 25.5, "epsTrailingTwelveMonths" => 5.88,
                 "dividendRate" => 0.96, "fiftyDayAverage" => 148.5,
-                "twoHundredDayAverage" => 145.0, "exDividendDate" => 1_710_374_400
+                "twoHundredDayAverage" => 145.0, "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0, "exDividendDate" => 1_710_374_400
               }
             ]
           }
@@ -608,7 +639,8 @@ RSpec.describe YahooFinanceClient::Stock do
         { symbol: "AAPL", name: "Apple Inc.", price: 150.0, change: 1.5,
           percent_change: 1.0, volume: 100_000, pe_ratio: 25.5, eps: 5.88,
           dividend: 0.96, dividend_yield: 0.64, payout_ratio: 16.33,
-          ma50: 148.5, ma200: 145.0, ex_dividend_date: Date.new(2024, 3, 14), dividend_date: nil }
+          ma50: 148.5, ma200: 145.0, fifty_two_week_high: 180.0, fifty_two_week_low: 120.0,
+          ex_dividend_date: Date.new(2024, 3, 14), dividend_date: nil }
       end
       let(:response_body) do
         {
@@ -620,7 +652,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "regularMarketChangePercent" => 0.53, "regularMarketVolume" => 90_000,
                 "trailingPE" => 35.0, "epsTrailingTwelveMonths" => 10.86,
                 "dividendRate" => 3.0, "fiftyDayAverage" => 375.0,
-                "twoHundredDayAverage" => 360.0, "exDividendDate" => 1_715_644_800
+                "twoHundredDayAverage" => 360.0, "fiftyTwoWeekHigh" => 420.0,
+                "fiftyTwoWeekLow" => 310.0, "exDividendDate" => 1_715_644_800
               }
             ]
           }
@@ -705,7 +738,8 @@ RSpec.describe YahooFinanceClient::Stock do
                 "regularMarketChangePercent" => 1.0, "regularMarketVolume" => 100_000,
                 "trailingPE" => 25.5, "epsTrailingTwelveMonths" => 5.88,
                 "dividendRate" => 0.96, "fiftyDayAverage" => 148.5,
-                "twoHundredDayAverage" => 145.0, "exDividendDate" => 1_710_374_400
+                "twoHundredDayAverage" => 145.0, "fiftyTwoWeekHigh" => 180.0,
+                "fiftyTwoWeekLow" => 120.0, "exDividendDate" => 1_710_374_400
               }
             ]
           }


### PR DESCRIPTION
## Summary
- Add `fifty_two_week_high` and `fifty_two_week_low` fields to quote hash from Yahoo Finance API
- Update all specs with new fields in mock responses and expected hashes
- Backfill CHANGELOG.md with missing version entries (0.2.0–0.4.0)
- Bump version to 0.4.1

## Test plan
- [x] `bundle exec rake` passes (42 examples, 0 failures)
- [x] RuboCop clean
- [ ] `gem push yahoo_finance_client-0.4.1.gem` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)