### PR TITLE
Expose currency field in quote results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.6.0] - 2026-05-16
+
+- Expose Yahoo's `currency` field in `get_quote` / `get_quotes` results so callers can support multi-currency portfolios
+
 ## [0.5.0] - 2026-05-15
 
 - Add `Stock.search(query, count:)` returning matching tickers from Yahoo's `v1/finance/search` autocomplete endpoint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yahoo_finance_client (0.5.0)
+    yahoo_finance_client (0.6.0)
       csv
       httparty (~> 0.21.0)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Fetch stock data by passing a ticker symbol:
 ```ruby
 YahooFinanceClient::Stock.get_quote("AAPL")
 # => {
-#   symbol: "AAPL", name: "Apple Inc.", price: 182.52,
+#   symbol: "AAPL", name: "Apple Inc.", price: 182.52, currency: "USD",
 #   change: 1.25, percent_change: 0.69, volume: 48123456,
 #   pe_ratio: 28.5, eps: 6.40,
 #   dividend: 0.96, dividend_yield: 0.53, payout_ratio: 15.0,

--- a/lib/yahoo_finance_client/stock.rb
+++ b/lib/yahoo_finance_client/stock.rb
@@ -162,7 +162,7 @@ module YahooFinanceClient
 
       def build_quote_hash(quote, price, dividend, eps)
         {
-          symbol: quote["symbol"], name: quote["shortName"], price: price,
+          symbol: quote["symbol"], name: quote["shortName"], price: price, currency: quote["currency"],
           change: quote["regularMarketChange"], percent_change: quote["regularMarketChangePercent"],
           volume: quote["regularMarketVolume"], pe_ratio: quote["trailingPE"], eps: eps,
           dividend: dividend, dividend_yield: calculate_yield(dividend, price),

--- a/lib/yahoo_finance_client/version.rb
+++ b/lib/yahoo_finance_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module YahooFinanceClient
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/yahoo_finance_client/stock_spec.rb
+++ b/spec/yahoo_finance_client/stock_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 150.0,
+          currency: nil,
           change: 1.5,
           percent_change: 1.0,
           volume: 100_000,
@@ -134,6 +135,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 150.0,
+          currency: nil,
           change: 1.5,
           percent_change: 1.0,
           volume: 100_000,
@@ -172,6 +174,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 150.0,
+          currency: nil,
           change: 1.5,
           percent_change: 1.0,
           volume: 100_000,
@@ -219,6 +222,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 155.0,
+          currency: nil,
           change: 2.0,
           percent_change: 1.3,
           volume: 120_000,
@@ -290,6 +294,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "GOOG",
           name: "Alphabet Inc.",
           price: 140.0,
+          currency: nil,
           change: -0.5,
           percent_change: -0.36,
           volume: 50_000,
@@ -381,6 +386,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "TSLA",
           name: "Tesla Inc.",
           price: 200.0,
+          currency: nil,
           change: 5.0,
           percent_change: 2.56,
           volume: 80_000,
@@ -440,6 +446,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 150.0,
+          currency: nil,
           change: 1.5,
           percent_change: 1.0,
           volume: 100_000,
@@ -467,6 +474,33 @@ RSpec.describe YahooFinanceClient::Stock do
       it "returns an authentication error message" do
         result = described_class.get_quote(symbol)
         expect(result).to eq(error: "Authentication failed after 2 retries")
+      end
+    end
+
+    context "when the response includes a currency" do
+      let(:response_body) do
+        {
+          "quoteResponse" => {
+            "result" => [
+              {
+                "symbol" => "IBE.MC", "shortName" => "Iberdrola, S.A.",
+                "regularMarketPrice" => 14.5, "regularMarketChange" => 0.1,
+                "regularMarketChangePercent" => 0.69, "regularMarketVolume" => 1_000_000,
+                "currency" => "EUR"
+              }
+            ]
+          }
+        }.to_json
+      end
+
+      before do
+        stub_request(:get, "#{base_url}/v7/finance/quote?symbols=IBE.MC&crumb=#{crumb}")
+          .to_return(status: 200, body: response_body)
+      end
+
+      it "exposes the currency field" do
+        result = described_class.get_quote("IBE.MC")
+        expect(result[:currency]).to eq("EUR")
       end
     end
 
@@ -512,6 +546,7 @@ RSpec.describe YahooFinanceClient::Stock do
           symbol: "AAPL",
           name: "Apple Inc.",
           price: 150.0,
+          currency: nil,
           change: 1.5,
           percent_change: 1.0,
           volume: 100_000,


### PR DESCRIPTION
## Summary
- Pass Yahoo's `currency` field through `build_quote_hash` so callers can support multi-currency portfolios without a second request.
- Bump version to **0.6.0**, update CHANGELOG/README.

## Why
Downstream apps (e.g. dividend-portfolio) need the listing currency to render non-USD stocks correctly and to split portfolio totals per currency. Yahoo already returns it on every quote — we were just discarding it.

## Test plan
- [x] `bundle exec rspec` — 63 examples, 0 failures (includes new "when the response includes a currency" case).
- [x] `bundle exec rubocop` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)